### PR TITLE
add option to build bot2-lcmgl with or without bot2-vis

### DIFF
--- a/bot2-lcmgl/CMakeLists.txt
+++ b/bot2-lcmgl/CMakeLists.txt
@@ -10,11 +10,16 @@ lcmtypes_build(JAVA_DEST_DIR ${PROJECT_SOURCE_DIR}/java/src
 
 set(ZLIB_LIBRARIES -lz)
 
+option(USE_BOT_VIS "Build bot2-lcmgl with libbot dependency." ON)
+
 add_definitions(-std=gnu99)
 
 add_subdirectory(src/bot_lcmgl_client)
 add_subdirectory(src/bot_lcmgl_render)
-add_subdirectory(src/lcmgl-viewer)
+
+if(USE_BOT_VIS)
+  add_subdirectory(src/lcmgl-viewer)
+endif()
 
 add_subdirectory(java)
 add_subdirectory(python)

--- a/bot2-lcmgl/src/bot_lcmgl_render/CMakeLists.txt
+++ b/bot2-lcmgl/src/bot_lcmgl_render/CMakeLists.txt
@@ -1,13 +1,24 @@
 add_definitions(-std=gnu99)
 
-file(GLOB c_files *.c)
-file(GLOB h_files *.h)
+set(c_files lcmgl_decode.c)
+set(h_files lcmgl_decode.h)
+set(REQUIRED_LIBS lcmtypes_bot2-lcmgl)
+
+if (USE_BOT_VIS)
+  list(APPEND c_files lcmgl_bot_renderer.c)
+  list(APPEND h_files lcmgl_decode.h)
+  list(APPEND REQUIRED_LIBS bot2-vis lcmtypes_bot2-lcmgl gl)
+  add_definitions(-DUSE_BOT_VIS)
+endif()
+
 
 add_library(bot2-lcmgl-renderer SHARED ${c_files})
 
-set(REQUIRED_LIBS bot2-vis lcmtypes_bot2-lcmgl gl)
+find_package(OpenGL REQUIRED)
+target_link_libraries(bot2-lcmgl-renderer ${OPENGL_LIBRARIES})
+
 pods_use_pkg_config_packages(bot2-lcmgl-renderer ${REQUIRED_LIBS})
-    
+
 
 # set the library API version.  Increment this every time the public API
 # changes.


### PR DESCRIPTION
By default, bot2-vis is enabled to preserve existing behavior.
However, when bot2-lcmgl is built without bot2-vis then its only
dependencies are lcm and OpenGl.  That removes the bot2-vis dependencies
such as gtk and x11.

Some features of lcmgl are not available when built without bot2-vis:
text and texture rendering.