### PR TITLE
Avoid calling pods_use_pkg_config_packages with an empty list

### DIFF
--- a/bot2-lcmgl/src/bot_lcmgl_render/CMakeLists.txt
+++ b/bot2-lcmgl/src/bot_lcmgl_render/CMakeLists.txt
@@ -2,7 +2,7 @@ add_definitions(-std=gnu99)
 
 set(c_files lcmgl_decode.c)
 set(h_files lcmgl_decode.h)
-set(REQUIRED_LIBS "")
+set(REQUIRED_LIBS)
 
 if (USE_BOT_VIS)
   list(APPEND c_files lcmgl_bot_renderer.c)
@@ -16,7 +16,11 @@ add_library(bot2-lcmgl-renderer SHARED ${c_files})
 
 find_package(OpenGL REQUIRED)
 target_link_libraries(bot2-lcmgl-renderer ${OPENGL_LIBRARIES} lcmtypes_bot2-lcmgl)
-pods_use_pkg_config_packages(bot2-lcmgl-renderer ${REQUIRED_LIBS})
+
+if(REQUIRED_LIBS)
+  pods_use_pkg_config_packages(bot2-lcmgl-renderer ${REQUIRED_LIBS})
+endif()
+
 list(APPEND REQUIRED_LIBS lcmtypes_bot2-lcmgl)
 
 


### PR DESCRIPTION
The macro is buggy.  It calls return() when given an empty list.
This doesn't do the right thing because it's a macro, so it actually
causes you to return from the current CMakeLists.txt.  In the updated
RobotLocomotion/cmake/pods.cmake the macro has been replaced with a
function.