### PR TITLE
merge libbot drc changes (rebased)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,14 +24,14 @@ endif()
 
 # Look for the gdkx.h header to decide whether the local gtk2 install has
 # X11 support or not.
-find_file(GDKX_HEADER gdkx.h PATH_SUFFIXES gtk-2.0/gdk)
-if(GDKXHEADER)
-  set(bot_vis_default ON)
-  message(STATUS "gdkx.h found, system appears to have gtk+X11 support")
-else()
-  set(bot_vis_default OFF)
-  message(STATUS "gdkx.h not found, system not appear to have gtk+X11 support")
-endif()
+#find_file(GDKX_HEADER gdkx.h PATH_SUFFIXES gtk-2.0/gdk)
+#if(GDKXHEADER)
+set(bot_vis_default ON)
+#  message(STATUS "gdkx.h found, system appears to have gtk+X11 support")
+#else()
+#set(bot_vis_default OFF)
+#message(STATUS "gdkx.h not found, system not appear to have gtk+X11 support")
+#endif()
 
 
 option(WITH_BOT_VIS "Build with bot2-vis" ${bot_vis_default})

--- a/bot2-core/.gitignore
+++ b/bot2-core/.gitignore
@@ -1,0 +1,1 @@
+/pod-build

--- a/bot2-core/lcmtypes/.gitignore
+++ b/bot2-core/lcmtypes/.gitignore
@@ -1,0 +1,4 @@
+/c
+/cpp
+/java
+/python

--- a/bot2-core/lcmtypes/bot_core_images_t.lcm
+++ b/bot2-core/lcmtypes/bot_core_images_t.lcm
@@ -1,0 +1,22 @@
+package bot_core;
+
+// simple array of images
+// originated in multisense driver
+
+struct images_t
+{
+  int64_t  utime;
+
+  int32_t  n_images;
+  int16_t image_types[n_images];     
+  image_t  images[n_images];
+ 
+  const int16_t LEFT=0;
+  const int16_t RIGHT=1;
+  const int16_t DISPARITY=2;         // 16bit as in the multisense
+  const int16_t MASK_ZIPPED=3;       // gray scale mask of left image, zipped with zlib
+  const int16_t DEPTH_MM=4;          // z depth, values similar to the OpenNI format
+  const int16_t DISPARITY_ZIPPED=5;  // 16bit as in the multisense, zipped with zlib 
+  const int16_t DEPTH_MM_ZIPPED=6;   // z depth, values similar to the OpenNI format, zipped with zlib
+  
+}

--- a/bot2-frames/.gitignore
+++ b/bot2-frames/.gitignore
@@ -1,0 +1,1 @@
+/pod-build

--- a/bot2-frames/cmake/pods.cmake
+++ b/bot2-frames/cmake/pods.cmake
@@ -307,7 +307,6 @@ macro(pods_use_pkg_config_packages target)
     string(STRIP ${_pods_pkg_ldflags} _pods_pkg_ldflags)
     #    message("ldflags: ${_pods_pkg_ldflags}")
     include_directories(${_pods_pkg_include_flags})
-    
     # make the target depend on libraries that are cmake targets
     if (_pods_pkg_ldflags)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})

--- a/bot2-frames/lcmtypes/.gitignore
+++ b/bot2-frames/lcmtypes/.gitignore
@@ -1,0 +1,5 @@
+/c
+/cpp
+/java
+/python
+

--- a/bot2-lcm-utils/.gitignore
+++ b/bot2-lcm-utils/.gitignore
@@ -1,0 +1,1 @@
+/pod-build

--- a/bot2-lcmgl/.gitignore
+++ b/bot2-lcmgl/.gitignore
@@ -1,0 +1,3 @@
+/pod-build
+/java/src/bot_lcmgl/data_t.java
+/python/src/bot_lcmgl/data_t.py

--- a/bot2-lcmgl/lcmtypes/.gitignore
+++ b/bot2-lcmgl/lcmtypes/.gitignore
@@ -1,0 +1,5 @@
+/c
+/cpp
+/java
+/python
+

--- a/bot2-param/.gitignore
+++ b/bot2-param/.gitignore
@@ -1,0 +1,1 @@
+/pod-build

--- a/bot2-param/lcmtypes/.gitignore
+++ b/bot2-param/lcmtypes/.gitignore
@@ -1,0 +1,5 @@
+/c
+/cpp
+/java
+/python
+

--- a/bot2-param/lcmtypes/bot_param_entry_t.lcm
+++ b/bot2-param/lcmtypes/bot_param_entry_t.lcm
@@ -2,6 +2,7 @@ package bot_param;
 
 struct entry_t
 {
-		string key;				//the key for this entry
+        boolean is_array;       //whether this represents an array of values
+        string key;             //the key for this entry
         string value;           //string containing the value for that key
 }

--- a/bot2-param/src/param_client/param_internal.c
+++ b/bot2-param/src/param_client/param_internal.c
@@ -370,6 +370,7 @@ new_element(const char * name)
 
 static void free_element(BotParamElement * el)
 {
+  if (el == NULL) return;
   free(el->name);
   BotParamElement * child, *next;
   for (child = el->children; child; child = next) {

--- a/bot2-param/src/param_client/param_internal.c
+++ b/bot2-param/src/param_client/param_internal.c
@@ -1523,8 +1523,10 @@ int bot_param_set_str_array(BotParam * param, const char * key, const char ** va
     return -1;
   }
 
+  BotParamElement* next = el->next;
   free_element(el);
   el = create_key(param->root, key);
+  el->next = next;
   int num_set = 0;
   for (int i = 0; i < len; ++i) {
     if (0 == add_value(NULL, el, vals[i])) ++num_set;

--- a/bot2-param/src/param_server/param_server.c
+++ b/bot2-param/src/param_server/param_server.c
@@ -201,13 +201,16 @@ int main(int argc, char ** argv)
 
   self->seqNo = 0;
   self->id = _timestamp_now();
-  self->params = bot_param_new_from_file(argv[optind]);
-  if (self->params==NULL){
-    fprintf(stderr, "Could not load params from %s\n", argv[optind]);
-    exit(1);
+  if (message_init_channel == NULL) {
+    self->params = bot_param_new_from_file(argv[optind]);
+    if (self->params==NULL){
+      fprintf(stderr, "Could not load params from %s\n", argv[optind]);
+      exit(1);
+    }
+    else{
+      fprintf(stderr, "Loaded params from %s\n", argv[optind]);
+    }
   }
-  else
-    fprintf(stderr, "Loaded params from %s\n", argv[optind]);
 
   // set channels here
   if (!param_prefix) param_prefix = getenv ("BOT_PARAM_SERVER_NAME");
@@ -223,6 +226,7 @@ int main(int argc, char ** argv)
   bot_param_set_t_subscribe(self->lcm, self->set_channel, on_param_set, (void *) self);
 
   if (message_init_channel != NULL) {
+      fprintf(stderr, "Listening to %s for params\n", message_init_channel);
       self->init_subscription = bot_param_update_t_subscribe(self->lcm, message_init_channel, on_param_init, (void *)self);
   }
 

--- a/bot2-param/src/param_server/param_server.c
+++ b/bot2-param/src/param_server/param_server.c
@@ -99,7 +99,7 @@ void on_param_set(const lcm_recv_buf_t *rbuf, const char * channel, const bot_pa
       success = (bot_param_set_str_array(self->params, msg->entries[i].key, vals, len) == len);
     }
     else {
-      success = (bot_param_set_str(self->params, msg->entries[i].key, msg->entries[i].value) == 0);
+      success = (bot_param_set_str(self->params, msg->entries[i].key, msg->entries[i].value) == 1);
     }
     if (success) {
       self->seqNo++;

--- a/bot2-param/src/param_server/param_server.c
+++ b/bot2-param/src/param_server/param_server.c
@@ -85,14 +85,13 @@ void on_param_set(const lcm_recv_buf_t *rbuf, const char * channel, const bot_pa
       int end_pos = 0;
       int cur_val = 0;
       for (int k = 0; k < string_len; ++k, ++end_pos) {
+        if (str[k] == ',') continue;
         if ((k == string_len-1) || (str[k+1] == ',')) {
           int substr_len = end_pos-start_pos+1;
           vals[cur_val] = malloc(substr_len+1);
           memcpy(vals[cur_val], str+start_pos, substr_len);
           vals[cur_val][substr_len] = '\0';
-          k++;
-          start_pos = k+1;
-          end_pos = start_pos;
+          start_pos = k+2;
           cur_val++;
         }
       }

--- a/bot2-param/src/param_server/param_tool.c
+++ b/bot2-param/src/param_server/param_tool.c
@@ -34,6 +34,7 @@ int main(int argc, char ** argv)
   msg.sequence_number = bot_param_get_seqno(param);
   msg.server_id = bot_param_get_server_id(param);
   bot_param_entry_t entry;
+  entry.is_array = 0;
   entry.key = argv[1];
   entry.value = argv[2];
   msg.numEntries = 1;

--- a/bot2-procman/.gitignore
+++ b/bot2-procman/.gitignore
@@ -1,0 +1,2 @@
+/pod-build
+/python/src/bot_procman/build_prefix.py

--- a/bot2-procman/lcmtypes/.gitignore
+++ b/bot2-procman/lcmtypes/.gitignore
@@ -1,0 +1,5 @@
+/c
+/cpp
+/java
+/python
+

--- a/bot2-procman/python/src/bot_procman/sheriff.py
+++ b/bot2-procman/python/src/bot_procman/sheriff.py
@@ -722,6 +722,8 @@ class Sheriff(object):
                     # what the deputy is reporting.
                     del deputy._commands[cmd.sheriff_id]
                     cmd.sheriff_id = cmd_msg.sheriff_id
+                    cmd.actual_runid = cmd_msg.actual_runid
+                    cmd.desired_runid = cmd.actual_runid
                     deputy._commands[cmd.sheriff_id] = cmd
                     _dbg("Merging command [%s] with command reported by deputy" \
                             % cmd.command_id)

--- a/bot2-vis/.gitignore
+++ b/bot2-vis/.gitignore
@@ -1,0 +1,1 @@
+/pod-build

--- a/bot2-vis/CMakeLists.txt
+++ b/bot2-vis/CMakeLists.txt
@@ -12,7 +12,8 @@ set(GLUT_LIBRARIES -lglut)
 
 set(ZLIB_LIBRARIES -lz)
 
-find_package(JPEG REQUIRED)
+set(LIBJPEG_CFLAGS "")
+set(LIBJPEG_LIBRARIES -ljpeg)
 
 add_definitions(-std=gnu99)
 

--- a/bot2-vis/src/bot_vis/CMakeLists.txt
+++ b/bot2-vis/src/bot_vis/CMakeLists.txt
@@ -4,11 +4,9 @@ file(GLOB h_files *.h)
 # Keep the GLM library out of the public API
 list(REMOVE_ITEM h_files glm.h)
 
-include_directories(${JPEG_INCLUDE_DIR})
-
 add_library(bot2-vis SHARED ${c_files})
 
-set(REQUIRED_LIBS ${JPEG_LIBRARY} ${GLUT_LIBRARIES} ${ZLIB_LIBRARIES})
+set(REQUIRED_LIBS ${LIBJPEG_LIBRARIES} ${GLUT_LIBRARIES} ${ZLIB_LIBRARIES})
 if (APPLE)  
 # note: the following lines will now work on every platform (and
 # really should be included), but they depend on a fix to pods.cmake,


### PR DESCRIPTION
This PR brings in about a dozen commits made mostly by @RussTedrake and  Matt over the course of the DRC.

libbot diverged during the competition and these commits sync it back up:
- fixed some parsing issues with bot param
- fixes to procman restarting processes when it was shut down and restarted
- bot_core_images type for multisense data

A number of commits from @RussTedrake have dropped out because they were committed in parallel to RL/libbot and the DRC fork.

This can be compared with this branch:
https://github.com/RobotLocomotion/libbot/compare/master...mitdrc:mfallon-merge-libbot-drc-changes-alpah
Which mitdrc/drc has been using for about 2 months.