### PR TITLE
typo in variable name in schedule_cmd_for_removal

### DIFF
--- a/bot2-procman/python/src/bot_procman/sheriff.py
+++ b/bot2-procman/python/src/bot_procman/sheriff.py
@@ -1040,8 +1040,8 @@ class Sheriff(object):
         """
         if self._is_observer:
             raise ValueError("Can't remove commands in Observer mode")
-        deputy = self.get_command_deputy(command)
-        status_changes = deputy._schedule_for_removal(command)
+        deputy = self.get_command_deputy(cmd)
+        status_changes = deputy._schedule_for_removal(cmd)
         self._maybe_emit_status_change_signals(deputy, status_changes)
         self.send_orders()
 


### PR DESCRIPTION
schedule_comand_for_removal function referenced `command` variable while `cmd` was passed in. believed to be a typo.