### PR TITLE
Add "dummy" install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,3 +115,5 @@ else()
     CMAKE_CACHE_ARGS ${default_cmake_args} -DUSE_BOT_VIS:BOOL=${WITH_BOT_VIS})
 
 endif()
+
+install(CODE "message(\"Nothing to do for install.\")")


### PR DESCRIPTION
Add some no-op install logic to force creation of an 'install' target. This allows for easier use of libbot via CMake external projects, by not requiring such users to explicitly disable the install step.

(In particular, this will newly allow drake to consume libbot as a "CMake POD".)