### PR TITLE
Typo in GDKX header; missing gthread-2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 # Look for the gdkx.h header to decide whether the local gtk2 install has
 # X11 support or not.
 find_file(GDKX_HEADER gdkx.h PATH_SUFFIXES gtk-2.0/gdk)
-if(GDKXHEADER)
+if(GDKX_HEADER)
   set(bot_vis_default ON)
   message(STATUS "gdkx.h found, system appears to have gtk+X11 support")
 else()

--- a/bot2-vis/src/bot_vis/CMakeLists.txt
+++ b/bot2-vis/src/bot_vis/CMakeLists.txt
@@ -21,7 +21,7 @@ endif(APPLE)
 
 target_link_libraries(bot2-vis ${REQUIRED_LIBS})
 
-set(REQUIRED_PACKAGES glib-2.0 gtk+-2.0 gdk-pixbuf-2.0 lcm bot2-core libpng gl glu)
+set(REQUIRED_PACKAGES glib-2.0 gtk+-2.0 gdk-pixbuf-2.0 lcm bot2-core libpng gl glu gthread-2.0)
 pods_use_pkg_config_packages(bot2-vis ${REQUIRED_PACKAGES})
 
 # set the library API version.  Increment this every time the public API


### PR DESCRIPTION
cmake variable is misspelled when setting bot_vis_default

also my system (ubuntu 14.04, cmake 3.2.2, gcc 4.8.4) needs gthread-2.0 as required package in bot_vis CMakeLists.txt for rwx-viewer to compile; otherwise link fails with g_thread_init not found